### PR TITLE
chore: agrega dependencias y plugin kapt para Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.google.services)
     id("androidx.navigation.safeargs")
-
+    kotlin("kapt")
 }
-
 
 android {
     namespace = "com.ebcf.jnab"
@@ -26,8 +25,7 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
         }
     }
@@ -44,13 +42,11 @@ android {
     }
 }
 
-
 dependencies {
     val nav_version = "2.8.9"
 
     // Jetpack Compose integration
     implementation("androidx.navigation:navigation-compose:$nav_version")
-
 
     // Views/Fragments integration
     implementation("androidx.navigation:navigation-fragment:$nav_version")
@@ -92,6 +88,18 @@ dependencies {
     implementation(libs.androidx.lifecycle.livedata.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.java.jwt)
+
+    // Implementacion principal de Room: la base para trabajar con la base de datos SQLite
+    implementation(libs.room.runtime)
+
+    // Extensiones para Kotlin y soporte a corrutinas en Room (suspend functions, Flow, etc.)
+    implementation(libs.room.ktx)
+
+    // Procesador de anotaciones para Room, necesario para generar el codigo automaticamente
+    kapt(libs.room.compiler)
+
+    // Biblioteca para hacer pruebas unitarias/instrumentadas con Room (base de datos en memoria, etc.)
+    testImplementation(libs.room.testing)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ lifecycleViewmodelKtx = "2.8.7"
 javaJwt = "3.18.2"
 firebaseBom = "33.13.0"
 googleServices = "4.4.2"
+room = "2.7.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -53,6 +54,10 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 java-jwt = { group = "com.auth0", name = "java-jwt", version.ref = "javaJwt" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Se agregan las dependencias necesarias para utilizar Room en el proyecto:

- implementation(libs.room.runtime): implementación principal de Room para SQLite.
- implementation(libs.room.ktx): extensiones Kotlin y soporte para corrutinas.
- kapt(libs.room.compiler): procesador de anotaciones para generar código.
- testImplementation(libs.room.testing): biblioteca para pruebas unitarias con Room.
- Aplicación del plugin kotlin("kapt") en build.gradle.kts para habilitar el procesador de anotaciones.

Esto permite trabajar con Room correctamente y preparar el proyecto para futuras pruebas unitarias.