### PR TITLE
chore: implementa objeto proveedor de la instancia de Firestore

### DIFF
--- a/app/src/main/java/com/ebcf/jnab/data/source/remote/FirebaseFirestoreProvider.kt
+++ b/app/src/main/java/com/ebcf/jnab/data/source/remote/FirebaseFirestoreProvider.kt
@@ -1,0 +1,9 @@
+package com.ebcf.jnab.data.source.remote
+
+import com.google.firebase.firestore.FirebaseFirestore
+
+object FirebaseFirestoreProvider {
+    fun provide(): FirebaseFirestore {
+        return FirebaseFirestore.getInstance()
+    }
+}


### PR DESCRIPTION
Se implementa un objeto Kotlin llamado FirebaseFirestoreProvider que provee la instancia de FirebaseFirestore. Al utilizar un object, se garantiza que este proveedor sea un singleton, es decir, solo existirá una única instancia de este objeto durante toda la ejecución de la aplicación. Esto simplifica el acceso y asegura que la instancia de Firestore se gestione de forma centralizada y consistente.